### PR TITLE
Spelling correction for Kappa's strength string

### DIFF
--- a/wwwroot/data/Monsters.json
+++ b/wwwroot/data/Monsters.json
@@ -281,7 +281,7 @@
     "experienceGained": 250,
     "hp": 290,
     "weakness": "Archery",
-    "strength": "Hamermanship",
+    "strength": "Hammermanship",
     "damage": 3,
     "armor": 6,
     "attackSpeed": 3,


### PR DESCRIPTION
Corrected the spelling of the strength string for the Kappa monster, which was preventing the Kappa from taking half damage from hammers.