### PR TITLE
submitHighScores toggle

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @inject HttpClient Http
 @inject GameState GameState
 @inject MessageManager MessageManager
@@ -118,17 +118,18 @@ else
     }
     private async void UpdateHighScores()
     {
-        if (Program.playfabManager.IsConnected == false && (GameState.userID == null || GameState.userID == ""))
+        if (GameState.submitHighScores)
         {
-            ConnectToKongregate();
+            if (Program.playfabManager.IsConnected == false && (GameState.userID == null || GameState.userID == ""))
+            {
+                ConnectToKongregate();
+            }
+            else
+            {
+                await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalLevelScore", GameState.GetPlayer().GetTotalLevel());
+                await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalKills", GameState.totalKills);
+            }
         }
-        else
-        {
-            await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalLevelScore", GameState.GetPlayer().GetTotalLevel());
-            await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalKills", GameState.totalKills);
-        }
-
-
     }
     public void GoToDebugArea()
     {
@@ -312,6 +313,7 @@ else
             {
                 GameState.totalDeaths = int.Parse(settings[7]);
             }
+            GameState.submitHighScores = bool.Parse(settings[8]);
         }
         if (lines.Length > 10 && lines[10] != null)
         {

--- a/Pages/Settings.razor
+++ b/Pages/Settings.razor
@@ -1,4 +1,4 @@
-﻿@page "/Settings"
+@page "/Settings"
 @inject HttpClient Http
 @inject GameState GameState
 @inject MessageManager MessageManager
@@ -13,6 +13,7 @@
 
 <p><button class="btn btn-primary" onclick="@(() => GameState.ToggleSplitView())">Toggle Split View</button> @GetOnOrOff(GameState.isSplitView)</p>
 <p><button class="btn btn-primary" onclick="@(() => GameState.ToggleBankStyle())">Toggle Compact Bank View</button>@GetOnOrOff(GameState.compactBankView)</p>
+<p><button class="btn btn-primary" onclick="@(() => GameState.ToggleSubmitHighScores())">Toggle Submit High Scores</button>@GetOnOrOff(GameState.submitHighScores)</p>
 
 <p>Set limit for selling confirmation:<input type="number" @bind-value="@Limit" @bind-value:event="onchange" /> Current:@GameState.expensiveItemThreshold</p>
 
@@ -161,6 +162,7 @@
             {
                 GameState.totalDeaths = int.Parse(settings[7]);
             }
+            GameState.submitHighScores = bool.Parse(settings[8]);
         }
         if (lines.Length > 10 && lines[10] != null)
         {
@@ -312,8 +314,11 @@
     }
     private async void UpdateHighScores()
     {
-        await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalLevelScore", GameState.GetPlayer().GetTotalLevel());
-        await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalKills", GameState.totalKills);
+        if (GameState.submitHighScores)
+        {
+            await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalLevelScore", GameState.GetPlayer().GetTotalLevel());
+            await JSRuntime.InvokeAsync<object>("kongregateFunctions.updateTotalKills", GameState.totalKills);
+        }
     }
     private string SaveDataEncrypted()
     {

--- a/Services/GameState.cs
+++ b/Services/GameState.cs
@@ -39,6 +39,7 @@ public class GameState
     public bool compactBankView;
     public bool autoBuySushiSupplies;
     public bool hideLockedItems;
+    public bool submitHighScores = true;
 
     public bool saveDataLoaded;
     public bool gameDataLoaded;
@@ -271,6 +272,10 @@ public class GameState
         inventoryIsActiveView = !inventoryIsActiveView;
         UpdateState();
     }
+    public void ToggleSubmitHighScores()
+    {
+        submitHighScores = !submitHighScores;
+    }
     public void IncrementKillCount(int monsterID)
     {
         killCount[monsterID] += 1;
@@ -345,6 +350,8 @@ public class GameState
         data += totalCoinsEarned;
         data += ",";
         data += totalDeaths;
+        data += ",";
+        data += submitHighScores.ToString();
         pos++;
         //NPC data 10
         data += "#";


### PR DESCRIPTION
Disable submitting Highscores to Kongregate. Ask cheaters to toggle this before cheating so they don't pollute the real highscores and they still can have their fun. A similar toggle is used in NGU Idle for this purpose.